### PR TITLE
Add Loyalty+ skeleton with Node and React

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# ASE-final
+# Loyalty+
+
+This repository contains a minimal full-stack skeleton for the Loyalty+ application.
+
+## Backend
+
+The backend is an Express.js server with PostgreSQL. It supports user registration, login, and a protected profile route using JWT authentication.
+
+### Setup
+
+```bash
+cd backend
+npm install
+cp .env.example .env
+npm start
+```
+
+## Frontend
+
+The frontend is a simple React app using Vite and TailwindCSS with a basic login form.
+
+### Setup
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+This minimal skeleton can be expanded to implement the full Loyalty+ feature set.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL=postgres://user:password@localhost:5432/loyalty
+JWT_SECRET=your_jwt_secret
+PORT=3001

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,3 @@
+const { Pool } = require('pg');
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+module.exports = pool;

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,79 @@
+const express = require('express');
+const cors = require('cors');
+const dotenv = require('dotenv');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const { Pool } = require('pg');
+const { v4: uuidv4 } = require('uuid');
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+function generateToken(user) {
+  return jwt.sign({ id: user.id, email: user.email }, process.env.JWT_SECRET, { expiresIn: '1h' });
+}
+
+app.post('/api/register', async (req, res) => {
+  const { email, password, username } = req.body;
+  if (!email || !password) return res.status(400).json({ message: 'Email and password required' });
+  const hashed = await bcrypt.hash(password, 10);
+  try {
+    const result = await pool.query(
+      'INSERT INTO users (id, email, password_hash, username) VALUES ($1,$2,$3,$4) RETURNING id, email',
+      [uuidv4(), email, hashed, username || null]
+    );
+    const token = generateToken(result.rows[0]);
+    res.json({ token });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Registration failed' });
+  }
+});
+
+app.post('/api/login', async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) return res.status(400).json({ message: 'Email and password required' });
+  try {
+    const result = await pool.query('SELECT * FROM users WHERE email = $1', [email]);
+    const user = result.rows[0];
+    if (!user) return res.status(401).json({ message: 'Invalid credentials' });
+    const match = await bcrypt.compare(password, user.password_hash);
+    if (!match) return res.status(401).json({ message: 'Invalid credentials' });
+    const token = generateToken(user);
+    res.json({ token });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Login failed' });
+  }
+});
+
+function authMiddleware(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return res.status(401).json({ message: 'Missing token' });
+  const token = authHeader.split(' ')[1];
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = payload;
+    next();
+  } catch {
+    res.status(401).json({ message: 'Invalid token' });
+  }
+}
+
+app.get('/api/profile', authMiddleware, async (req, res) => {
+  try {
+    const result = await pool.query('SELECT id, email, username FROM users WHERE id = $1', [req.user.id]);
+    res.json(result.rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to fetch profile' });
+  }
+});
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => console.log(`Server running on port ${port}`));

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^5.1.0",
+    "pg": "^8.16.0",
+    "dotenv": "^16.5.0",
+    "bcrypt": "^6.0.0",
+    "jsonwebtoken": "^9.0.2",
+    "cors": "^2.8.5"
+  }
+}

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,0 +1,9 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  username TEXT,
+  verified BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Loyalty+</title>
+    <link rel="stylesheet" href="/src/index.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "vite": "^6.3.5",
+    "@vitejs/plugin-react": "^4.5.2",
+    "tailwindcss": "^4.1.8",
+    "postcss": "^8.5.4",
+    "autoprefixer": "^10.4.21"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+
+export default function App() {
+  const [token, setToken] = useState(null);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  async function login(e) {
+    e.preventDefault();
+    const res = await fetch('http://localhost:3001/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    const data = await res.json();
+    if (data.token) setToken(data.token);
+  }
+
+  if (token) {
+    return <div className="p-4">Logged in!</div>;
+  }
+
+  return (
+    <form onSubmit={login} className="p-4 space-y-2 max-w-xs">
+      <h1 className="text-xl font-bold">Login</h1>
+      <input
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+        className="border p-2 w-full"
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+        className="border p-2 w-full"
+      />
+      <button className="bg-blue-500 text-white px-4 py-2">Login</button>
+    </form>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,5 @@
+export default {
+  content: ["./index.html", "./src/**/*.{js,jsx}"],
+  theme: { extend: {} },
+  plugins: [],
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 5173 },
+});


### PR DESCRIPTION
## Summary
- initialize Express backend with JWT auth and PostgreSQL
- add React frontend using Vite and TailwindCSS
- provide example environment file and database schema
- update README with setup instructions
- ignore node modules

## Testing
- `npm test` in `backend` *(fails: Missing script)*
- `npm test` in `frontend` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_68484ea02aa88331bd1f062e602ece18